### PR TITLE
chore: update repo metadata, templates, and install docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/ecosystem_project.yml
+++ b/.github/ISSUE_TEMPLATE/ecosystem_project.yml
@@ -1,0 +1,91 @@
+name: Ecosystem project request
+description: Submit a project to be listed on the AgentPay ecosystem page
+title: "[Ecosystem] "
+labels:
+  - ecosystem
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in being listed on the AgentPay ecosystem page!
+        Please fill out the details below so we can review your project.
+  - type: input
+    id: project-name
+    attributes:
+      label: Project name
+      placeholder: e.g. Acme Payments
+    validations:
+      required: true
+  - type: input
+    id: website
+    attributes:
+      label: Website URL
+      placeholder: https://example.com
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Short description
+      description: A one-liner describing what your project does (max ~100 characters).
+      placeholder: e.g. On-ramp and checkout infrastructure for buying and selling crypto.
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Which area best describes your project?
+      options:
+        - Payments
+        - Infrastructure
+        - DeFi
+        - FX and remittance
+        - Merchant acquiring
+        - Card issuing
+        - Enterprise treasury
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: integration
+    attributes:
+      label: AgentPay SDK integration
+      description: Describe how your project uses or plans to use the AgentPay SDK.
+    validations:
+      required: true
+  - type: dropdown
+    id: status
+    attributes:
+      label: Integration status
+      options:
+        - Live — already using the SDK in production
+        - In development — actively building the integration
+        - Planned — integration not yet started
+    validations:
+      required: true
+  - type: input
+    id: logo
+    attributes:
+      label: Logo URL
+      description: Link to a square logo (PNG or SVG, min 128x128px). We may ask for a higher-res version.
+      placeholder: https://example.com/logo.png
+    validations:
+      required: false
+  - type: input
+    id: contact
+    attributes:
+      label: Contact
+      description: How can we reach you? (email, X/Twitter handle, or Telegram)
+      placeholder: "@handle or email"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submit checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This project uses or will use the AgentPay SDK.
+          required: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 World Liberty Financial LLC
+Copyright (c) 2026 SC Financial Technologies LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ The full one-click installer does not require local Cargo, pnpm, or a preinstall
 
 ```bash
 pnpm install
-npm run build
-npm run install:cli-launcher
-npm run install:rust-binaries
+pnpm run build
+pnpm run install:cli-launcher
+pnpm run install:rust-binaries
 ```
 
 On macOS, add `export PATH="$HOME/.agentpay/bin:$PATH"` to `~/.zshrc`, then reload your shell with `source ~/.zshrc`.
@@ -77,9 +77,9 @@ On Linux, add `export PATH="$HOME/.agentpay/bin:$PATH"` to your shell startup fi
 
 ```bash
 pnpm install
-npm run build
-npm run install:cli-launcher
-npm run install:rust-binaries
+pnpm run build
+pnpm run install:cli-launcher
+pnpm run install:rust-binaries
 ```
 
 - If you only need to reconnect the current local vault after refreshing the runtime, use `agentpay admin setup --reuse-existing-wallet`

--- a/skills/agentpay-sdk/references/install-and-workflows.md
+++ b/skills/agentpay-sdk/references/install-and-workflows.md
@@ -70,9 +70,9 @@ From a repo checkout:
 
 ```bash
 pnpm install
-npm run build
-npm run install:cli-launcher
-npm run install:rust-binaries
+pnpm run build
+pnpm run install:cli-launcher
+pnpm run install:rust-binaries
 ```
 
 One-click updates use the same bootstrap entrypoint:


### PR DESCRIPTION
## Summary

This PR bundles a few small repository maintenance updates.
It adds a new GitHub issue template for ecosystem project submissions, updates the LICENSE copyright holder, and fixes installation docs that still referenced `npm run` instead of `pnpm run`.
Together these changes keep repository metadata current, improve contributor intake, and align setup instructions with the repo's actual package manager workflow.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test-only
- [ ] Security hardening

## Linked Issues

Closes #

## What Was Changed

- Added `.github/ISSUE_TEMPLATE/ecosystem_project.yml` for structured ecosystem project submission requests
- Updated `LICENSE` to reflect the current copyright holder
- Replaced outdated `npm run` commands with `pnpm run` in `README.md`
- Updated the same install commands in `skills/agentpay-sdk/references/install-and-workflows.md` to keep the workflow reference consistent

## Validation

Not run; this PR only changes repository metadata, GitHub templates, and documentation.

## Security and Risk Checklist

- [x] No new secrets, private keys, or tokens added
- [x] Inputs and permissions were reviewed for abuse paths
- [x] Backward compatibility considered (or migration notes included)

## Docs Checklist

- [x] README/CLI help/docs updated for user-facing changes
- [ ] Breaking changes documented

No breaking changes in this PR.

## Screenshots or Logs (if relevant)

Not applicable.