### PR TITLE
Fix macOS default bash installer compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -13,6 +13,7 @@ PUBLIC_RELEASE_TAG="${AGENTPAY_PUBLIC_RELEASE_TAG:-__AGENTPAY_PUBLIC_RELEASE_TAG
 LEGACY_RELAY_MODE="${AGENTPAY_SETUP_RELAY_MODE:-}"
 INSTALLER_MODE_DEFAULT="${AGENTPAY_SETUP_MODE:-full}"
 AUTO_CONTINUE_SECONDS="${AGENTPAY_SETUP_AUTO_CONTINUE_SECONDS:-8}"
+KEY_SEQUENCE_TIMEOUT_SECONDS="${AGENTPAY_SETUP_KEY_SEQUENCE_TIMEOUT_SECONDS:-0.05}"
 NODE_MIN_MAJOR=20
 RETRY_ATTEMPTS=3
 RETRY_DELAY_SECONDS=2
@@ -77,6 +78,12 @@ on_error() {
 }
 
 trap 'on_error $? $LINENO' ERR
+
+configure_bash_compatibility() {
+  if (( BASH_VERSINFO[0] < 4 )); then
+    KEY_SEQUENCE_TIMEOUT_SECONDS="${AGENTPAY_SETUP_KEY_SEQUENCE_TIMEOUT_SECONDS:-1}"
+  fi
+}
 
 usage() {
   cat <<'EOF_USAGE'
@@ -226,7 +233,12 @@ init_prompt_io() {
   fi
 
   if [[ -r /dev/tty ]] && [[ -w /dev/tty ]]; then
-    exec {PROMPT_IN_FD}<>/dev/tty
+    if (( BASH_VERSINFO[0] >= 4 )); then
+      exec {PROMPT_IN_FD}<>/dev/tty
+    else
+      PROMPT_IN_FD=3
+      exec 3<>/dev/tty
+    fi
     PROMPT_OUT_FD="$PROMPT_IN_FD"
     PROMPT_IN="/dev/tty"
     PROMPT_OUT="/dev/tty"
@@ -1502,9 +1514,9 @@ read_skill_target_picker_key() {
   fi
 
   if [[ "$key" == $'\033' ]]; then
-    if IFS= read -r -u "$PROMPT_IN_FD" -s -n 1 -t 0.05 next; then
+    if IFS= read -r -u "$PROMPT_IN_FD" -s -n 1 -t "$KEY_SEQUENCE_TIMEOUT_SECONDS" next; then
       key+="$next"
-      if [[ "$next" == "[" ]] && IFS= read -r -u "$PROMPT_IN_FD" -s -n 1 -t 0.05 next; then
+      if [[ "$next" == "[" ]] && IFS= read -r -u "$PROMPT_IN_FD" -s -n 1 -t "$KEY_SEQUENCE_TIMEOUT_SECONDS" next; then
         key+="$next"
       fi
     fi
@@ -2020,6 +2032,7 @@ cleanup_temp_bundle() {
 main() {
   parse_args "$@"
 
+  configure_bash_compatibility
   init_prompt_io
   validate_installer_modes
 


### PR DESCRIPTION
## Summary

The one-click installer currently fails on macOS machines that still use the system `/bin/bash` (GNU Bash 3.2).
It uses dynamic file descriptor allocation (`exec {PROMPT_IN_FD}<>/dev/tty`) and fractional `read -t` timeouts, both of which are unsupported in Bash 3.2.
This change adds a Bash-version compatibility shim so the installer can continue to prompt through `/dev/tty` and parse arrow-key input on the default macOS shell.
It also updates CI concurrency grouping so the same branch does not run duplicate `push` and `pull_request` workflows in parallel.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test-only
- [ ] Security hardening

## Linked Issues

Closes #

## What Was Changed

- added `configure_bash_compatibility()` to adjust installer behavior for Bash versions older than 4
- used a fixed fallback file descriptor (`3`) for `/dev/tty` when running under Bash 3.2
- replaced hard-coded fractional arrow-key read timeouts with a configurable compatibility-safe timeout
- invoked the compatibility setup before prompt I/O is initialized
- changed the CI concurrency key to use the source repository and branch name so matching `push` and `pull_request` runs deduplicate against each other

## Validation

- [ ] `npm run test`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `cargo test --workspace` (if Rust crates changed)
- [ ] Added or updated tests for changed behavior

Validated manually with:
- `/bin/bash -n scripts/installer.sh`
- `bash -n scripts/installer.sh`
- sourced `scripts/installer.sh` under `/bin/bash` in a pseudo-TTY and verified `init_prompt_io` opens `/dev/tty` on fd `3` with a Bash 3.2-safe timeout
- parsed `.github/workflows/ci.yml` with Ruby after the concurrency update to confirm valid workflow YAML

## Security and Risk Checklist

- [x] No new secrets, private keys, or tokens added
- [x] Inputs and permissions were reviewed for abuse paths
- [x] Backward compatibility considered (or migration notes included)

## Docs Checklist

- [ ] README/CLI help/docs updated for user-facing changes
- [ ] Breaking changes documented

No docs update is required because these changes preserve the documented install and CI workflows while fixing compatibility and duplicate execution.

## Screenshots or Logs (if relevant)

Attach sanitized artifacts only.
