### PR TITLE
Bump installer smoke Rust toolchain to 1.89.0

### DIFF
--- a/.github/workflows/installer-smoke-macos.yml
+++ b/.github/workflows/installer-smoke-macos.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.87.0
+          toolchain: 1.89.0
 
       - name: Validate installer scripts
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Organized in dependency layers:
 - **tsup** bundles the CLI to `dist/cli.cjs` (CJS, node20 target, with shebang)
 - **Cargo** workspace for Rust crates
 - **Biome** for formatting/linting (line width 100, single quotes, 2-space indent, trailing commas)
-- **Rust 1.87.0+** minimum required
+- **Rust 1.89.0+** minimum required
 
 ## Testing
 


### PR DESCRIPTION
solana-sdk 4.0.1 transitively pulls in solana-* and wincode crates that now require rustc 1.89.0, breaking the installer smoke job pinned to 1.87.0.