### PR TITLE
Add Solayer Pay plugin

### DIFF
--- a/crates/vault-cli-agent/src/main.rs
+++ b/crates/vault-cli-agent/src/main.rs
@@ -198,6 +198,17 @@ enum Commands {
         #[arg(long, value_parser = parse_positive_u128)]
         rent_lamports: u128,
     },
+    #[command(about = "Request a scoped Solana message signature through policy checks")]
+    SolanaMessageSign {
+        #[arg(long, value_parser = parse_positive_u64)]
+        network: u64,
+        #[arg(long)]
+        address: SolanaAddress,
+        #[arg(long)]
+        domain: String,
+        #[arg(long)]
+        message: String,
+    },
     #[command(about = "Submit an ERC-20 approve request through policy checks")]
     Approve {
         #[arg(long, value_parser = parse_positive_u64)]
@@ -732,6 +743,53 @@ where
                 output_format,
                 quiet,
             );
+            print_agent_output(&output, output_format, output_target)?;
+        }
+        Commands::SolanaMessageSign {
+            network,
+            address,
+            domain,
+            message,
+        } => {
+            let address_str = address.to_string();
+            print_status(
+                "submitting solana message signing request",
+                output_format,
+                quiet,
+            );
+            let signature = match await_signature_or_handle_manual_approval(
+                "solana-message-sign",
+                daemon_socket,
+                output_format,
+                output_target,
+                sdk.solana_message_sign(network, address, domain, message),
+            )
+            .await?
+            {
+                Some(signature) => signature,
+                None => return Ok(CommandRunOutcome::ManualApprovalRequired),
+            };
+            let (signature_hex, r_hex, s_hex, v) = signature_output_parts(&signature);
+            let output = AgentCommandOutput {
+                command: "solana-message-sign".to_string(),
+                network: network.to_string(),
+                asset: "native_sol".to_string(),
+                counterparty: address_str,
+                amount_wei: "0".to_string(),
+                estimated_max_gas_spend_wei: None,
+                tx_type: None,
+                delegation_enabled: None,
+                signature_hex,
+                signature_base58: signature.signature_base58.clone(),
+                r_hex,
+                s_hex,
+                v,
+                raw_tx_hex: None,
+                tx_hash_hex: None,
+                raw_tx_base64: None,
+                tx_id: None,
+            };
+            print_status("solana message signed", output_format, quiet);
             print_agent_output(&output, output_format, output_target)?;
         }
         Commands::Approve {

--- a/crates/vault-cli-daemon/src/relay_sync.rs
+++ b/crates/vault-cli-daemon/src/relay_sync.rs
@@ -900,6 +900,7 @@ fn action_name(action: &AgentAction) -> &'static str {
         AgentAction::SolanaSplTransfer { .. } => "transfer",
         AgentAction::SolanaSolTransfer { .. } => "transfer_native",
         AgentAction::SolanaNonceAccountCreate { .. } => "solana_nonce_account_create",
+        AgentAction::SolanaMessageSigning { .. } => "solana_message_sign",
         AgentAction::TransferNative { .. } => "transfer_native",
         AgentAction::Permit2Permit { .. } => "permit2_permit",
         AgentAction::Eip3009TransferWithAuthorization { .. } => {

--- a/crates/vault-daemon/src/daemon_parts/api_impl_and_utils.rs
+++ b/crates/vault-daemon/src/daemon_parts/api_impl_and_utils.rs
@@ -175,7 +175,10 @@ where
                 vault_keys.insert(vault_key.id, vault_key.clone());
             })
         {
-            if let Err(cleanup_err) = self.signer_backend.delete_vault_key_if_present(vault_key.id) {
+            if let Err(cleanup_err) = self
+                .signer_backend
+                .delete_vault_key_if_present(vault_key.id)
+            {
                 return Err(DaemonError::Signer(SignerError::Internal(format!(
                     "create_vault_key cleanup failed after error `{err}`: {cleanup_err}"
                 ))));
@@ -183,7 +186,10 @@ where
             return Err(err);
         }
         if let Err(err) = self.persist_or_revert(backup) {
-            if let Err(cleanup_err) = self.signer_backend.delete_vault_key_if_present(vault_key.id) {
+            if let Err(cleanup_err) = self
+                .signer_backend
+                .delete_vault_key_if_present(vault_key.id)
+            {
                 return Err(DaemonError::Signer(SignerError::Internal(format!(
                     "create_vault_key cleanup failed after error `{err}`: {cleanup_err}"
                 ))));
@@ -840,14 +846,14 @@ where
                                 &relay_private_key_hex,
                                 approval_request_id,
                             )
-                                .ok()
-                                .and_then(|approval_capability| {
-                                    manual_approval_frontend_url(
-                                        &relay_config,
-                                        approval_request_id,
-                                        &approval_capability,
-                                    )
-                                });
+                            .ok()
+                            .and_then(|approval_capability| {
+                                manual_approval_frontend_url(
+                                    &relay_config,
+                                    approval_request_id,
+                                    &approval_capability,
+                                )
+                            });
                             self.persist_or_revert(backup)?;
                             return Err(DaemonError::ManualApprovalRequired {
                                 approval_request_id,
@@ -890,14 +896,14 @@ where
                                 &relay_private_key_hex,
                                 approval_request_id,
                             )
-                                .ok()
-                                .and_then(|approval_capability| {
-                                    manual_approval_frontend_url(
-                                        &relay_config,
-                                        approval_request_id,
-                                        &approval_capability,
-                                    )
-                                });
+                            .ok()
+                            .and_then(|approval_capability| {
+                                manual_approval_frontend_url(
+                                    &relay_config,
+                                    approval_request_id,
+                                    &approval_capability,
+                                )
+                            });
                             self.persist_or_revert(backup)?;
                             return Err(DaemonError::ManualApprovalRequired {
                                 approval_request_id,
@@ -907,7 +913,10 @@ where
                         }
                     }
                 }
-                PolicyDecision::Deny(PolicyError::Eip712ManualApprovalRequired { policy_id, .. }) => {
+                PolicyDecision::Deny(PolicyError::Eip712ManualApprovalRequired {
+                    policy_id,
+                    ..
+                }) => {
                     ensure_action_supports_manual_approval(&payload_action)?;
                     let payload_hash = payload_hash_hex(&request.payload);
                     // Read the relay secret before creating or mutating approval state so a
@@ -939,14 +948,14 @@ where
                                 &relay_private_key_hex,
                                 approval_request_id,
                             )
-                                .ok()
-                                .and_then(|approval_capability| {
-                                    manual_approval_frontend_url(
-                                        &relay_config,
-                                        approval_request_id,
-                                        &approval_capability,
-                                    )
-                                });
+                            .ok()
+                            .and_then(|approval_capability| {
+                                manual_approval_frontend_url(
+                                    &relay_config,
+                                    approval_request_id,
+                                    &approval_capability,
+                                )
+                            });
                             self.persist_or_revert(backup)?;
                             return Err(DaemonError::ManualApprovalRequired {
                                 approval_request_id,
@@ -999,6 +1008,11 @@ where
                 }
                 AgentAction::SolanaNonceAccountCreate { create } => {
                     self.sign_solana_nonce_account_create(&vault_key, create)
+                        .await?
+                }
+                AgentAction::SolanaMessageSigning { message } => {
+                    self.signer_backend
+                        .sign_solana_payload(vault_key.id, message.message.as_bytes())
                         .await?
                 }
                 AgentAction::Permit2Permit { .. }
@@ -1370,7 +1384,9 @@ fn ensure_action_supports_manual_approval(action: &AgentAction) -> Result<(), Da
     Ok(())
 }
 
-fn prepare_loaded_state(mut state: PersistedDaemonState) -> Result<PersistedDaemonState, DaemonError> {
+fn prepare_loaded_state(
+    mut state: PersistedDaemonState,
+) -> Result<PersistedDaemonState, DaemonError> {
     ensure_relay_identity(&mut state);
     normalize_disabled_policy_set_attachments(&mut state);
     validate_loaded_state(&state)?;

--- a/crates/vault-domain/src/action.rs
+++ b/crates/vault-domain/src/action.rs
@@ -9,6 +9,8 @@ use crate::constants::{canonical_policy_chain_id, is_solana_chain_id};
 use crate::u128_as_decimal_string;
 use crate::{AssetId, DomainError, EvmAddress, RecipientId, SolanaAddress};
 
+const MAX_SOLANA_SIGNING_MESSAGE_BYTES: usize = 4 * 1024;
+
 sol! {
     function approve(address spender, uint256 value);
     function transfer(address to, uint256 value);
@@ -647,6 +649,37 @@ impl FromStr for SolanaTokenProgram {
     }
 }
 
+/// Scoped Solana message signing request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SolanaMessageSigning {
+    /// Internal Solana network id.
+    pub chain_id: u64,
+    /// Solana wallet address expected to sign the message.
+    pub address: SolanaAddress,
+    /// External domain requesting the signature.
+    pub domain: String,
+    /// UTF-8 message bytes to sign.
+    pub message: String,
+}
+
+impl SolanaMessageSigning {
+    pub fn validate(&self) -> Result<(), DomainError> {
+        if !is_solana_chain_id(self.chain_id) {
+            return Err(DomainError::InvalidChainId);
+        }
+        let _ = self.address.to_bytes()?;
+        let domain = self.domain.trim();
+        if domain != "solayer" {
+            return Err(DomainError::InvalidSolanaMessage);
+        }
+        let message = self.message.as_bytes();
+        if message.is_empty() || message.len() > MAX_SOLANA_SIGNING_MESSAGE_BYTES {
+            return Err(DomainError::InvalidSolanaMessage);
+        }
+        Ok(())
+    }
+}
+
 /// Constrained native SOL transfer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SolanaSolTransfer {
@@ -892,6 +925,8 @@ pub enum AgentAction {
         /// Unsinged tx fields to authorize and sign.
         tx: BroadcastTx,
     },
+    /// Scoped Solana message signing request.
+    SolanaMessageSigning { message: SolanaMessageSigning },
     /// Constrained native SOL transfer request.
     SolanaSolTransfer { transfer: SolanaSolTransfer },
     /// Constrained Solana SPL token transfer request.
@@ -918,6 +953,7 @@ impl AgentAction {
             Self::TempoSessionVoucher { authorization } => authorization.amount_wei,
             Self::Eip712TypedData { .. } => 0,
             Self::BroadcastTx { tx } => self.broadcast_effective_amount_wei(tx),
+            Self::SolanaMessageSigning { .. } => 0,
             Self::SolanaSolTransfer { transfer } => transfer.amount_wei,
             Self::SolanaSplTransfer { transfer } => transfer.amount_wei,
             Self::SolanaNonceAccountCreate { create } => create.rent_lamports,
@@ -939,6 +975,7 @@ impl AgentAction {
             Self::TempoSessionVoucher { authorization } => authorization.chain_id,
             Self::Eip712TypedData { typed_data } => typed_data.chain_id().unwrap_or_default(),
             Self::BroadcastTx { tx } => tx.chain_id,
+            Self::SolanaMessageSigning { message } => canonical_policy_chain_id(message.chain_id),
             Self::SolanaSolTransfer { transfer } => canonical_policy_chain_id(transfer.chain_id),
             Self::SolanaSplTransfer { transfer } => canonical_policy_chain_id(transfer.chain_id),
             Self::SolanaNonceAccountCreate { create } => canonical_policy_chain_id(create.chain_id),
@@ -969,6 +1006,7 @@ impl AgentAction {
             }
             Self::Eip712TypedData { .. } => AssetId::NativeEth,
             Self::BroadcastTx { tx } => self.broadcast_effective_asset(tx),
+            Self::SolanaMessageSigning { .. } => AssetId::NativeSol,
             Self::SolanaSolTransfer { .. } => AssetId::NativeSol,
             Self::SolanaSplTransfer { transfer } => AssetId::SplToken(transfer.mint.clone()),
             Self::SolanaNonceAccountCreate { .. } => AssetId::NativeSol,
@@ -1005,6 +1043,7 @@ impl AgentAction {
                     .unwrap_or_else(zero_evm_address),
             ),
             Self::BroadcastTx { tx } => self.broadcast_effective_recipient(tx),
+            Self::SolanaMessageSigning { message } => RecipientId::Solana(message.address.clone()),
             Self::SolanaSolTransfer { transfer } => RecipientId::Solana(transfer.to.clone()),
             Self::SolanaSplTransfer { transfer } => {
                 RecipientId::Solana(transfer.recipient_owner.clone())
@@ -1077,7 +1116,9 @@ impl AgentAction {
     pub fn records_spend_event(&self) -> bool {
         !matches!(
             self,
-            Self::Eip712TypedData { .. } | Self::SolanaNonceAccountCreate { .. }
+            Self::Eip712TypedData { .. }
+                | Self::SolanaMessageSigning { .. }
+                | Self::SolanaNonceAccountCreate { .. }
         )
     }
 
@@ -1123,6 +1164,7 @@ impl AgentAction {
             Self::TempoSessionTopUpTransaction { authorization } => authorization.validate(),
             Self::TempoSessionVoucher { authorization } => authorization.validate(),
             Self::Eip712TypedData { typed_data } => typed_data.validate(),
+            Self::SolanaMessageSigning { message } => message.validate(),
             Self::SolanaSolTransfer { transfer } => transfer.validate(),
             Self::SolanaSplTransfer { transfer } => transfer.validate(),
             Self::SolanaNonceAccountCreate { create } => create.validate(),

--- a/crates/vault-domain/src/error.rs
+++ b/crates/vault-domain/src/error.rs
@@ -77,6 +77,9 @@ pub enum DomainError {
     /// Solana durable nonce seed was invalid.
     #[error("solana nonce account seed must be non-empty ASCII and at most 32 bytes")]
     InvalidSolanaNonceSeed,
+    /// Solana message signing payload was invalid.
+    #[error("solana message signing payload is invalid")]
+    InvalidSolanaMessage,
     /// Action requested a signer algorithm that does not match the wallet key.
     #[error("signer key algorithm does not support this action")]
     InvalidKeyAlgorithmForAction,

--- a/crates/vault-domain/src/lib.rs
+++ b/crates/vault-domain/src/lib.rs
@@ -22,8 +22,8 @@ mod u128_as_decimal_string;
 
 pub use action::{
     action_from_erc20_calldata, parse_erc20_call, AgentAction, BroadcastTx, Eip3009Transfer,
-    Eip712TypedData, Erc20Call, Permit2Permit, SolanaNonceAccountCreate, SolanaSolTransfer,
-    SolanaSplTransfer, SolanaTokenProgram, TempoSessionOpenTransaction,
+    Eip712TypedData, Erc20Call, Permit2Permit, SolanaMessageSigning, SolanaNonceAccountCreate,
+    SolanaSolTransfer, SolanaSplTransfer, SolanaTokenProgram, TempoSessionOpenTransaction,
     TempoSessionTopUpTransaction, TempoSessionVoucher,
 };
 pub use address::{EvmAddress, RecipientId, SolanaAddress};

--- a/crates/vault-sdk-agent/src/lib.rs
+++ b/crates/vault-sdk-agent/src/lib.rs
@@ -13,8 +13,9 @@ use vault_domain::{
     action_from_erc20_calldata, AgentAction, AgentCredentials, BroadcastTx, DomainError,
     Eip3009Transfer, Eip712TypedData, EvmAddress, NonceReleaseRequest, NonceReservation,
     NonceReservationRequest, Permit2Permit, SignRequest, Signature, SolanaAddress,
-    SolanaNonceAccountCreate, SolanaSolTransfer, SolanaSplTransfer, SolanaTokenProgram,
-    TempoSessionOpenTransaction, TempoSessionTopUpTransaction, TempoSessionVoucher,
+    SolanaMessageSigning, SolanaNonceAccountCreate, SolanaSolTransfer, SolanaSplTransfer,
+    SolanaTokenProgram, TempoSessionOpenTransaction, TempoSessionTopUpTransaction,
+    TempoSessionVoucher,
 };
 use zeroize::Zeroizing;
 
@@ -100,6 +101,15 @@ pub trait AgentOperations: Send + Sync {
         nonce_account: SolanaAddress,
         seed: String,
         rent_lamports: u128,
+    ) -> Result<Signature, AgentSdkError>;
+
+    /// Requests a scoped Solana message signature.
+    async fn solana_message_sign(
+        &self,
+        chain_id: u64,
+        address: SolanaAddress,
+        domain: String,
+        message: String,
     ) -> Result<Signature, AgentSdkError>;
 
     /// Requests a Permit2 `PermitSingle` signature.
@@ -359,6 +369,24 @@ where
                 nonce_account,
                 seed,
                 rent_lamports,
+            },
+        })
+        .await
+    }
+
+    async fn solana_message_sign(
+        &self,
+        chain_id: u64,
+        address: SolanaAddress,
+        domain: String,
+        message: String,
+    ) -> Result<Signature, AgentSdkError> {
+        self.sign_action(AgentAction::SolanaMessageSigning {
+            message: SolanaMessageSigning {
+                chain_id,
+                address,
+                domain,
+                message,
             },
         })
         .await

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,8 +145,7 @@ import {
 import { registerBuiltinCliPlugins } from './plugins/index.js';
 
 type SolanaTransferModule = typeof import('./lib/solana-transfer.js');
-type SolanaDurableNonceContext =
-  import('./lib/solana-transfer.js').SolanaDurableNonceContext;
+type SolanaDurableNonceContext = import('./lib/solana-transfer.js').SolanaDurableNonceContext;
 
 let solanaTransferModulePromise: Promise<SolanaTransferModule> | undefined;
 
@@ -4977,6 +4976,42 @@ async function main() {
       },
       formatOutput: formatBroadcastedAssetOutput,
       reportOnchainReceiptStatus,
+    },
+    solana: {
+      resolveWalletAddress: async (config) => {
+        const { resolveSolanaWalletAddress } = await loadSolanaTransferModule();
+        return resolveSolanaWalletAddress(config);
+      },
+      resolveSolTransferContext: async (input) => {
+        const { resolveSolanaSolTransferContext } = await loadSolanaTransferModule();
+        return resolveSolanaSolTransferContext(input);
+      },
+      resolveSplTransferContext: async (input) => {
+        const { resolveSolanaTransferContext } = await loadSolanaTransferModule();
+        return resolveSolanaTransferContext(input);
+      },
+      resolveTransferFee: async (input) => {
+        const { resolveSolanaTransferFee } = await loadSolanaTransferModule();
+        return resolveSolanaTransferFee(input);
+      },
+      resolveComputeBudget: async (input) => {
+        const { resolveSolanaComputeBudget } = await loadSolanaTransferModule();
+        return resolveSolanaComputeBudget(input);
+      },
+      resolveDurableNonceForBroadcast: (input) =>
+        resolveSolanaDurableNonceForBroadcast({
+          ...input,
+          auth: input.auth as AgentCommandAuthOptions,
+        }),
+      broadcastSignedTransaction: async (rpcUrl, signedTransactionBase64) => {
+        const { broadcastSignedSolanaTransaction } = await loadSolanaTransferModule();
+        return broadcastSignedSolanaTransaction(rpcUrl, signedTransactionBase64);
+      },
+      reportSignatureStatus: reportSolanaSignatureStatus,
+      defaults: {
+        solTransferComputeUnitLimit: SOLANA_SOL_TRANSFER_COMPUTE_UNIT_LIMIT,
+        splTransferComputeUnitLimit: SOLANA_SPL_TRANSFER_COMPUTE_UNIT_LIMIT,
+      },
     },
     exitCodes: {
       challengeRequired: BITREFILL_CHALLENGE_EXIT_CODE,

--- a/src/lib/solayer.js
+++ b/src/lib/solayer.js
@@ -1,0 +1,1 @@
+export * from './solayer.ts';

--- a/src/lib/solayer.ts
+++ b/src/lib/solayer.ts
@@ -1,0 +1,1084 @@
+import { Buffer } from 'node:buffer';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertSafeRpcUrl, ensureAgentPayHome } from '../../packages/config/src/index.js';
+
+const DEFAULT_SOLAYER_BASE_URL = 'https://app.solayer.org/api';
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const SOLAYER_PLUGIN_DIR = 'solayer';
+const SOLAYER_SESSION_FILE = 'session.json';
+const MAX_GRPC_WEB_MESSAGE_BYTES = 8 * 1024 * 1024;
+
+export enum SolayerNetwork {
+  Unspecified = 0,
+  SolanaMainnet = 1,
+  SolanaTestnet = 2,
+}
+
+export enum SolayerSignatureMessageType {
+  WalletMessage = 0,
+  WalletTransaction = 1,
+}
+
+export enum SolayerEmailType {
+  Notification = 0,
+  Kyc = 1,
+  Student = 2,
+  Login = 3,
+  Delete = 4,
+  SetPin = 5,
+}
+
+export enum SolayerCardType {
+  Virtual = 0,
+  Physical = 1,
+}
+
+export enum SolayerCardLimitPeriod {
+  Unspecified = 0,
+  Day = 1,
+  Week = 2,
+  Month = 3,
+  Year = 4,
+  Total = 5,
+}
+
+export interface SolayerHttpTransport {
+  request(method: string, body: Uint8Array, headers: Record<string, string>): Promise<Uint8Array>;
+}
+
+export interface SolayerClientOptions {
+  baseUrl?: string;
+  token?: string | null;
+  deviceId?: string;
+  timeoutMs?: number;
+  transport?: SolayerHttpTransport;
+}
+
+export interface SolayerSession {
+  token: string;
+  deviceId: string;
+  updatedAt: string;
+}
+
+export interface SolayerDevice {
+  name: string;
+  mode?: string;
+  browser?: string;
+  os: string;
+  osVersion: string;
+}
+
+export interface SolayerCardCondition {
+  period?: SolayerCardLimitPeriod;
+  valueInUsd?: string;
+}
+
+export interface SolayerBilling {
+  line1?: string | null;
+  line2?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postalCode?: string | null;
+  countryCode?: string | null;
+  country?: string | null;
+}
+
+export interface SolayerShipping extends SolayerBilling {
+  phoneNumber?: string | null;
+  method?: number;
+  firstName?: string | null;
+  lastName?: string | null;
+  dialCode?: string | null;
+}
+
+export interface SolayerCard {
+  uuid: string;
+  last4: string | null;
+  expirationData: string | null;
+  status: number;
+  tokenWallets: string[];
+  limit: SolayerCardCondition | null;
+  name: string | null;
+  billing: SolayerBilling | null;
+  shipping: SolayerShipping | null;
+  timestamp: string | null;
+  type: number;
+}
+
+export interface SolayerCardTransaction {
+  uuid: string;
+  type: number;
+  card: SolayerCard | null;
+  amount: string | null;
+  currency: string | null;
+  timestamp: string | null;
+  status: number;
+  notes: string | null;
+  merchant: Record<string, string | null> | null;
+  failedReason: number;
+  failedMessage: string | null;
+}
+
+export interface SolayerApplication {
+  uuid: string;
+  applicationStatus: number;
+  msg: string | null;
+  completionLink: string | null;
+  handle: number;
+  operation: number;
+  link: string | null;
+}
+
+export interface SolayerKycInfo {
+  kycStatus: number;
+  kyc: {
+    applicantId: string | null;
+    email: string | null;
+    country: string | null;
+  } | null;
+  msg: string | null;
+  operation: number;
+  itemKyc: boolean;
+  needKycMetadata: boolean;
+}
+
+export interface SolayerGrpcStatus {
+  code?: number;
+  message?: string | null;
+  raw?: Record<number, ProtoValue[]>;
+}
+
+type ProtoPrimitive = bigint | string | Uint8Array | boolean;
+
+interface ProtoValue {
+  wireType: number;
+  value: ProtoPrimitive;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
+function ensureSolayerPluginDir(): string {
+  const pluginDir = path.join(ensureAgentPayHome(), 'plugins', SOLAYER_PLUGIN_DIR);
+  fs.mkdirSync(pluginDir, { recursive: true, mode: 0o700 });
+  return pluginDir;
+}
+
+function solayerSessionPath(): string {
+  return path.join(ensureSolayerPluginDir(), SOLAYER_SESSION_FILE);
+}
+
+export function readStoredSolayerSession(): SolayerSession | null {
+  const filePath = solayerSessionPath();
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(raw) as Partial<SolayerSession>;
+  const token = normalizeString(parsed.token);
+  const deviceId = normalizeString(parsed.deviceId);
+  const updatedAt = normalizeString(parsed.updatedAt);
+  if (!token || !deviceId || !updatedAt) {
+    return null;
+  }
+  return { token, deviceId, updatedAt };
+}
+
+export function storeSolayerSession(input: { token: string; deviceId: string }): SolayerSession {
+  const token = normalizeString(input.token);
+  const deviceId = normalizeString(input.deviceId);
+  if (!token) {
+    throw new Error('Solayer session token is required');
+  }
+  if (!deviceId) {
+    throw new Error('Solayer device id is required');
+  }
+  const session = {
+    token,
+    deviceId,
+    updatedAt: new Date().toISOString(),
+  };
+  const filePath = solayerSessionPath();
+  fs.writeFileSync(filePath, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {}
+  return session;
+}
+
+export function deleteStoredSolayerSession(): boolean {
+  const filePath = solayerSessionPath();
+  try {
+    fs.unlinkSync(filePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export function resolveSolayerBaseUrl(value = process.env.AGENTPAY_SOLAYER_BASE_URL): string {
+  return assertSafeRpcUrl(value?.trim() || DEFAULT_SOLAYER_BASE_URL, 'solayerBaseUrl');
+}
+
+export function resolveSolayerNetwork(network: string | undefined): SolayerNetwork {
+  const normalized = (network ?? 'solana-mainnet').trim().toLowerCase();
+  switch (normalized) {
+    case 'solana':
+    case 'solana-mainnet':
+    case 'mainnet':
+      return SolayerNetwork.SolanaMainnet;
+    case 'solana-testnet':
+    case 'testnet':
+      return SolayerNetwork.SolanaTestnet;
+    default:
+      throw new Error(`network '${network}' is not supported by Solayer`);
+  }
+}
+
+export function createSolayerDevice(): SolayerDevice {
+  return {
+    name: 'AgentPay CLI',
+    mode: 'cli',
+    browser: 'AgentPay',
+    os: process.platform,
+    osVersion: process.version,
+  };
+}
+
+function normalizeDeviceId(value: string | undefined): string {
+  const normalized = normalizeString(value);
+  if (normalized) {
+    return normalized;
+  }
+  return randomUUID();
+}
+
+function writeVarint(value: bigint): Uint8Array {
+  if (value < 0n) {
+    throw new Error('protobuf varint must be non-negative');
+  }
+  const bytes: number[] = [];
+  let remaining = value;
+  while (remaining >= 0x80n) {
+    bytes.push(Number((remaining & 0x7fn) | 0x80n));
+    remaining >>= 7n;
+  }
+  bytes.push(Number(remaining));
+  return Uint8Array.from(bytes);
+}
+
+function concatBytes(chunks: Uint8Array[]): Uint8Array {
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function protoKey(fieldNumber: number, wireType: number): Uint8Array {
+  return writeVarint(BigInt((fieldNumber << 3) | wireType));
+}
+
+function protoVarint(
+  fieldNumber: number,
+  value: number | bigint | boolean | undefined | null,
+): Uint8Array[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  const normalized =
+    typeof value === 'boolean'
+      ? value
+        ? 1n
+        : 0n
+      : typeof value === 'number'
+        ? BigInt(value)
+        : value;
+  return [protoKey(fieldNumber, 0), writeVarint(normalized)];
+}
+
+function protoString(fieldNumber: number, value: string | undefined | null): Uint8Array[] {
+  if (value === undefined || value === null || value === '') {
+    return [];
+  }
+  const bytes = Buffer.from(value, 'utf8');
+  return [protoKey(fieldNumber, 2), writeVarint(BigInt(bytes.length)), bytes];
+}
+
+function protoBytes(fieldNumber: number, value: Uint8Array | undefined | null): Uint8Array[] {
+  if (!value || value.length === 0) {
+    return [];
+  }
+  return [protoKey(fieldNumber, 2), writeVarint(BigInt(value.length)), value];
+}
+
+function protoMessage(fieldNumber: number, value: Uint8Array | undefined | null): Uint8Array[] {
+  if (!value) {
+    return [];
+  }
+  return [protoKey(fieldNumber, 2), writeVarint(BigInt(value.length)), value];
+}
+
+function encodeMessage(chunks: Uint8Array[][]): Uint8Array {
+  return concatBytes(chunks.flat());
+}
+
+function readVarint(bytes: Uint8Array, offset: number): { value: bigint; offset: number } {
+  let result = 0n;
+  let shift = 0n;
+  let cursor = offset;
+  while (cursor < bytes.length) {
+    const byte = bytes[cursor++];
+    result |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      return { value: result, offset: cursor };
+    }
+    shift += 7n;
+    if (shift > 70n) {
+      throw new Error('protobuf varint is too long');
+    }
+  }
+  throw new Error('protobuf varint is truncated');
+}
+
+function decodeMessage(bytes: Uint8Array): Record<number, ProtoValue[]> {
+  const fields: Record<number, ProtoValue[]> = {};
+  let offset = 0;
+  while (offset < bytes.length) {
+    const key = readVarint(bytes, offset);
+    offset = key.offset;
+    const fieldNumber = Number(key.value >> 3n);
+    const wireType = Number(key.value & 7n);
+    let value: ProtoPrimitive;
+    if (wireType === 0) {
+      const decoded = readVarint(bytes, offset);
+      offset = decoded.offset;
+      value = decoded.value;
+    } else if (wireType === 2) {
+      const length = readVarint(bytes, offset);
+      offset = length.offset;
+      const size = Number(length.value);
+      if (!Number.isSafeInteger(size) || size < 0 || offset + size > bytes.length) {
+        throw new Error('protobuf length-delimited field is invalid');
+      }
+      value = bytes.slice(offset, offset + size);
+      offset += size;
+    } else {
+      throw new Error(`unsupported protobuf wire type ${wireType}`);
+    }
+    const entries = fields[fieldNumber] ?? [];
+    entries.push({ wireType, value });
+    fields[fieldNumber] = entries;
+  }
+  return fields;
+}
+
+function field(fields: Record<number, ProtoValue[]>, no: number): ProtoValue | undefined {
+  return fields[no]?.[0];
+}
+
+function fields(fields: Record<number, ProtoValue[]>, no: number): ProtoValue[] {
+  return fields[no] ?? [];
+}
+
+function fieldString(fields: Record<number, ProtoValue[]>, no: number): string | null {
+  const value = field(fields, no)?.value;
+  if (!(value instanceof Uint8Array)) {
+    return null;
+  }
+  const decoded = Buffer.from(value).toString('utf8');
+  return decoded.length ? decoded : null;
+}
+
+function fieldBool(fields: Record<number, ProtoValue[]>, no: number): boolean {
+  const value = field(fields, no)?.value;
+  return typeof value === 'bigint' ? value !== 0n : false;
+}
+
+function fieldNumber(fields: Record<number, ProtoValue[]>, no: number): number {
+  const value = field(fields, no)?.value;
+  return typeof value === 'bigint' ? Number(value) : 0;
+}
+
+function fieldUint64String(fields: Record<number, ProtoValue[]>, no: number): string | null {
+  const value = field(fields, no)?.value;
+  return typeof value === 'bigint' ? value.toString() : null;
+}
+
+function fieldMessage(
+  fieldsMap: Record<number, ProtoValue[]>,
+  no: number,
+): Record<number, ProtoValue[]> | null {
+  const value = field(fieldsMap, no)?.value;
+  if (!(value instanceof Uint8Array)) {
+    return null;
+  }
+  return decodeMessage(value);
+}
+
+function fieldMessages(
+  fieldsMap: Record<number, ProtoValue[]>,
+  no: number,
+): Record<number, ProtoValue[]>[] {
+  return fields(fieldsMap, no).flatMap((entry) =>
+    entry.value instanceof Uint8Array ? [decodeMessage(entry.value)] : [],
+  );
+}
+
+function encodeGrpcWebMessage(message: Uint8Array): Uint8Array {
+  if (message.length > MAX_GRPC_WEB_MESSAGE_BYTES) {
+    throw new Error('Solayer gRPC message is too large');
+  }
+  const output = new Uint8Array(5 + message.length);
+  output[0] = 0;
+  new DataView(output.buffer).setUint32(1, message.length, false);
+  output.set(message, 5);
+  return output;
+}
+
+function decodeGrpcWebMessage(body: Uint8Array): Uint8Array {
+  let offset = 0;
+  while (offset + 5 <= body.length) {
+    const frameType = body[offset];
+    const length = new DataView(body.buffer, body.byteOffset + offset + 1, 4).getUint32(0, false);
+    offset += 5;
+    if (offset + length > body.length) {
+      throw new Error('Solayer gRPC-web response frame is truncated');
+    }
+    const frame = body.slice(offset, offset + length);
+    offset += length;
+    if ((frameType & 0x80) === 0) {
+      return frame;
+    }
+  }
+  throw new Error('Solayer gRPC-web response did not include a data frame');
+}
+
+function encodeDevice(device: SolayerDevice): Uint8Array {
+  return encodeMessage([
+    protoString(1, device.name),
+    protoString(2, device.mode),
+    protoString(3, device.browser),
+    protoString(4, device.os),
+    protoString(5, device.osVersion),
+  ]);
+}
+
+function encodeCardCondition(condition: SolayerCardCondition | undefined): Uint8Array | undefined {
+  if (!condition) {
+    return undefined;
+  }
+  return encodeMessage([
+    protoVarint(1, condition.period ?? SolayerCardLimitPeriod.Unspecified),
+    protoString(2, condition.valueInUsd),
+  ]);
+}
+
+function decodeStatus(message: Record<number, ProtoValue[]> | null): SolayerGrpcStatus | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    code: fieldNumber(message, 1),
+    message: fieldString(message, 2),
+    raw: message,
+  };
+}
+
+function decodeCondition(
+  message: Record<number, ProtoValue[]> | null,
+): SolayerCardCondition | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    period: fieldNumber(message, 1),
+    valueInUsd: fieldString(message, 2) ?? undefined,
+  };
+}
+
+function decodeBilling(message: Record<number, ProtoValue[]> | null): SolayerBilling | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    line1: fieldString(message, 1),
+    line2: fieldString(message, 2),
+    city: fieldString(message, 3),
+    region: fieldString(message, 4),
+    postalCode: fieldString(message, 5),
+    countryCode: fieldString(message, 6),
+    country: fieldString(message, 7),
+  };
+}
+
+function decodeShipping(message: Record<number, ProtoValue[]> | null): SolayerShipping | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    ...decodeBilling(message),
+    phoneNumber: fieldString(message, 8),
+    method: fieldNumber(message, 9),
+    firstName: fieldString(message, 10),
+    lastName: fieldString(message, 11),
+    dialCode: fieldString(message, 12),
+  };
+}
+
+function decodeCard(message: Record<number, ProtoValue[]> | null): SolayerCard | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    uuid: fieldString(message, 1) ?? '',
+    last4: fieldString(message, 2),
+    expirationData: fieldString(message, 3),
+    status: fieldNumber(message, 4),
+    tokenWallets: fields(message, 5).flatMap((entry) =>
+      entry.value instanceof Uint8Array ? [Buffer.from(entry.value).toString('utf8')] : [],
+    ),
+    limit: decodeCondition(fieldMessage(message, 6)),
+    name: fieldString(message, 7),
+    billing: decodeBilling(fieldMessage(message, 8)),
+    shipping: decodeShipping(fieldMessage(message, 9)),
+    timestamp: fieldUint64String(message, 10),
+    type: fieldNumber(message, 11),
+  };
+}
+
+function decodeMerchant(
+  message: Record<number, ProtoValue[]> | null,
+): Record<string, string | null> | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    name: fieldString(message, 1),
+    city: fieldString(message, 2),
+    country: fieldString(message, 3),
+    category: fieldString(message, 4),
+    categoryCode: fieldString(message, 5),
+    enrichedName: fieldString(message, 6),
+    enrichedCategory: fieldString(message, 7),
+    enrichedIcon: fieldString(message, 8),
+    contact: fieldString(message, 9),
+  };
+}
+
+function decodeCardTransaction(message: Record<number, ProtoValue[]>): SolayerCardTransaction {
+  return {
+    uuid: fieldString(message, 1) ?? '',
+    type: fieldNumber(message, 2),
+    card: decodeCard(fieldMessage(message, 3)),
+    amount: fieldString(message, 4),
+    currency: fieldString(message, 5),
+    timestamp: fieldUint64String(message, 6),
+    status: fieldNumber(message, 7),
+    notes: fieldString(message, 8),
+    merchant: decodeMerchant(fieldMessage(message, 9)),
+    failedReason: fieldNumber(message, 10),
+    failedMessage: fieldString(message, 11),
+  };
+}
+
+function decodeApplication(
+  message: Record<number, ProtoValue[]> | null,
+): SolayerApplication | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    uuid: fieldString(message, 1) ?? '',
+    applicationStatus: fieldNumber(message, 2),
+    msg: fieldString(message, 3),
+    completionLink: fieldString(message, 4),
+    handle: fieldNumber(message, 5),
+    operation: fieldNumber(message, 6),
+    link: fieldString(message, 7),
+  };
+}
+
+function decodeKycInfo(message: Record<number, ProtoValue[]> | null): SolayerKycInfo | null {
+  if (!message) {
+    return null;
+  }
+  const kyc = fieldMessage(message, 2);
+  return {
+    kycStatus: fieldNumber(message, 1),
+    kyc: kyc
+      ? {
+          applicantId: fieldString(kyc, 1),
+          email: fieldString(kyc, 2),
+          country: fieldString(kyc, 3),
+        }
+      : null,
+    msg: fieldString(message, 3),
+    operation: fieldNumber(message, 4),
+    itemKyc: fieldBool(message, 5),
+    needKycMetadata: fieldBool(message, 6),
+  };
+}
+
+function decodeCardEncrypted(
+  message: Record<number, ProtoValue[]> | null,
+): { pan: string | null; cvc: string | null } | null {
+  if (!message) {
+    return null;
+  }
+  return {
+    pan: fieldString(message, 1),
+    cvc: fieldString(message, 2),
+  };
+}
+
+export function redactSolayerSensitiveFields<T>(value: T, revealSensitive = false): T {
+  if (revealSensitive) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSolayerSensitiveFields(entry, false)) as T;
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  const output: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (['pan', 'cvc', 'pin', 'token'].includes(key)) {
+      continue;
+    }
+    output[key] = redactSolayerSensitiveFields(entry, false);
+  }
+  return output as T;
+}
+
+class FetchSolayerTransport implements SolayerHttpTransport {
+  readonly baseUrl: string;
+  readonly timeoutMs: number;
+
+  constructor(baseUrl: string, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
+    this.baseUrl = assertSafeRpcUrl(baseUrl, 'solayerBaseUrl').replace(/\/+$/u, '');
+    this.timeoutMs = timeoutMs;
+  }
+
+  async request(
+    method: string,
+    body: Uint8Array,
+    headers: Record<string, string>,
+  ): Promise<Uint8Array> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(`${this.baseUrl}/solayerservice.v1.SolayerService/${method}`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/grpc-web+proto',
+          'x-grpc-web': '1',
+          ...headers,
+        },
+        body: encodeGrpcWebMessage(body),
+        signal: controller.signal,
+      });
+      const responseBody = new Uint8Array(await response.arrayBuffer());
+      if (!response.ok) {
+        throw new Error(`Solayer ${method} failed with HTTP ${response.status}`);
+      }
+      return decodeGrpcWebMessage(responseBody);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export class SolayerClient {
+  readonly token: string | null;
+  readonly deviceId: string;
+  readonly transport: SolayerHttpTransport;
+
+  constructor(options: SolayerClientOptions = {}) {
+    this.token = normalizeString(options.token);
+    this.deviceId = normalizeDeviceId(options.deviceId);
+    this.transport =
+      options.transport ??
+      new FetchSolayerTransport(
+        resolveSolayerBaseUrl(options.baseUrl),
+        options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      );
+  }
+
+  headers(authenticated: boolean): Record<string, string> {
+    const headers: Record<string, string> = {
+      platform: 'WEB',
+      'browser-id': this.deviceId,
+      'user-agent': 'AgentPay CLI',
+    };
+    if (authenticated) {
+      if (!this.token) {
+        throw new Error('Solayer login is required; run `agentpay solayer login ...` first');
+      }
+      headers.authorization = this.token;
+    }
+    return headers;
+  }
+
+  async call(
+    method: string,
+    body: Uint8Array,
+    authenticated: boolean,
+  ): Promise<Record<number, ProtoValue[]>> {
+    return decodeMessage(await this.transport.request(method, body, this.headers(authenticated)));
+  }
+
+  async getSignatureMessage(input: {
+    network: SolayerNetwork;
+    address: string;
+    messageType?: SolayerSignatureMessageType;
+  }) {
+    const response = await this.call(
+      'GetSignatureMessage',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoString(2, input.address),
+        protoVarint(3, input.messageType ?? SolayerSignatureMessageType.WalletMessage),
+      ]),
+      false,
+    );
+    return {
+      message: fieldString(response, 1) ?? '',
+      messageId: fieldString(response, 2) ?? '',
+    };
+  }
+
+  async verifySignature(input: {
+    network: SolayerNetwork;
+    address: string;
+    signature: Uint8Array;
+    messageId: string;
+    walletName: string;
+    txB64?: string;
+  }) {
+    const response = await this.call(
+      'VerifySignature',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoString(2, input.address),
+        protoBytes(3, input.signature),
+        protoString(4, input.messageId),
+        protoString(5, input.walletName),
+        protoString(6, input.txB64),
+      ]),
+      false,
+    );
+    return { token: fieldString(response, 1) ?? '' };
+  }
+
+  async sendEmail(input: { network: SolayerNetwork; email: string; emailType: SolayerEmailType }) {
+    const response = await this.call(
+      'SendEmail',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoString(2, input.email),
+        protoVarint(3, input.emailType),
+      ]),
+      false,
+    );
+    return {
+      sessionId: fieldString(response, 1) ?? '',
+      error: decodeStatus(fieldMessage(response, 2)),
+    };
+  }
+
+  async verifyEmailOtp(input: {
+    network: SolayerNetwork;
+    sessionId: string;
+    otp: string;
+    emailType: SolayerEmailType;
+  }) {
+    const response = await this.call(
+      'VerifyEmailOTP',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoString(2, input.sessionId),
+        protoString(3, input.otp),
+        protoVarint(4, input.emailType),
+      ]),
+      false,
+    );
+    return {
+      sessionId: fieldString(response, 1) ?? '',
+      error: decodeStatus(fieldMessage(response, 2)),
+    };
+  }
+
+  async checkAccount(input: { emailToken?: string; googleToken?: string; appleToken?: string }) {
+    const response = await this.call(
+      'CheckAccount',
+      encodeMessage([
+        protoString(1, input.googleToken),
+        protoString(2, input.appleToken),
+        protoString(3, input.emailToken),
+      ]),
+      false,
+    );
+    return {
+      exists: fieldBool(response, 1),
+      sessionId: fieldString(response, 2) ?? '',
+    };
+  }
+
+  async signIn(sessionId: string, device = createSolayerDevice()) {
+    const response = await this.call(
+      'SignIn',
+      encodeMessage([protoString(1, sessionId), protoMessage(2, encodeDevice(device))]),
+      false,
+    );
+    return {
+      token: fieldString(response, 1) ?? '',
+      tfaSessionId: fieldString(response, 3),
+    };
+  }
+
+  async signUp(sessionId: string, device = createSolayerDevice()) {
+    const response = await this.call(
+      'SignUp',
+      encodeMessage([protoString(1, sessionId), protoMessage(2, encodeDevice(device))]),
+      false,
+    );
+    return {
+      token: fieldString(response, 1) ?? '',
+      error: decodeStatus(fieldMessage(response, 3)),
+      tfaSessionId: fieldString(response, 4),
+    };
+  }
+
+  async logout() {
+    await this.call('Logout', new Uint8Array(), true);
+  }
+
+  async getAccountInfo() {
+    const response = await this.call('GetAccountInfo', new Uint8Array(), true);
+    const account = fieldMessage(response, 1);
+    return {
+      address: account ? fieldString(account, 1) : null,
+      subscribeEmail: account ? fieldString(account, 2) : null,
+      uuid: account ? fieldString(account, 16) : null,
+      name: account ? fieldString(account, 17) : null,
+      tester: account ? fieldBool(account, 18) : false,
+    };
+  }
+
+  async getDepositAddress(network: SolayerNetwork) {
+    const response = await this.call(
+      'GetDepositAddress',
+      encodeMessage([protoVarint(1, network)]),
+      true,
+    );
+    return { depositAddress: fieldString(response, 1) ?? '' };
+  }
+
+  async getKycInfo(network: SolayerNetwork) {
+    const response = await this.call('GetKYCInfo', encodeMessage([protoVarint(1, network)]), true);
+    return { kycInfo: decodeKycInfo(fieldMessage(response, 1)) };
+  }
+
+  async getKycAuth(network: SolayerNetwork) {
+    const response = await this.call('GetKYCAuth', encodeMessage([protoVarint(1, network)]), true);
+    return { link: fieldString(response, 1) ?? '' };
+  }
+
+  async acceptProtocol(input: { kyc?: boolean; card?: boolean }) {
+    await this.call('AcceptProtocol', encodeMessage([protoVarint(input.kyc ? 1 : 2, true)]), true);
+  }
+
+  async getApplication(network: SolayerNetwork) {
+    const response = await this.call(
+      'GetApplication',
+      encodeMessage([protoVarint(1, network)]),
+      true,
+    );
+    return { application: decodeApplication(fieldMessage(response, 1)) };
+  }
+
+  async createApplication(network: SolayerNetwork) {
+    const response = await this.call(
+      'CreateApplication',
+      encodeMessage([protoVarint(1, network)]),
+      true,
+    );
+    return { application: decodeApplication(fieldMessage(response, 1)) };
+  }
+
+  async updateApplication(network: SolayerNetwork) {
+    const response = await this.call(
+      'UpdateApplication',
+      encodeMessage([protoVarint(1, network)]),
+      true,
+    );
+    return { application: decodeApplication(fieldMessage(response, 1)) };
+  }
+
+  async getCards(input: { network: SolayerNetwork; limit?: SolayerCardCondition }) {
+    const response = await this.call(
+      'GetCards',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoMessage(2, encodeCardCondition(input.limit)),
+      ]),
+      true,
+    );
+    return {
+      balance: fieldString(response, 1),
+      pendingBalance: fieldString(response, 2),
+      cards: fieldMessages(response, 3)
+        .map(decodeCard)
+        .filter((entry): entry is SolayerCard => Boolean(entry)),
+      itemCard: fieldBool(response, 4),
+    };
+  }
+
+  async createCard(input: {
+    network: SolayerNetwork;
+    name?: string;
+    type: SolayerCardType;
+    limit?: SolayerCardCondition;
+  }) {
+    const response = await this.call(
+      'CreateCard',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoMessage(2, encodeCardCondition(input.limit)),
+        protoString(3, input.name),
+        protoVarint(4, input.type),
+      ]),
+      true,
+    );
+    return {
+      card: decodeCard(fieldMessage(response, 1)),
+      pan: fieldString(response, 2),
+      cvc: fieldString(response, 3),
+      error: decodeStatus(fieldMessage(response, 4)),
+    };
+  }
+
+  async getCardEncryptedInfo(input: {
+    network: SolayerNetwork;
+    cardId: string;
+    tfaSessionId?: string;
+  }) {
+    const response = await this.call(
+      'GetCardEncryptedInfo',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoString(2, input.cardId),
+        protoString(3, input.tfaSessionId),
+      ]),
+      true,
+    );
+    return { cardEncryptedInfo: decodeCardEncrypted(fieldMessage(response, 1)) };
+  }
+
+  async getCardDetails(input: { network: SolayerNetwork; cardId: string }) {
+    const response = await this.call(
+      'GetCardDetails',
+      encodeMessage([protoVarint(1, input.network), protoString(2, input.cardId)]),
+      true,
+    );
+    return {
+      card: decodeCard(fieldMessage(response, 1)),
+      usedAmount: fieldString(response, 2),
+      resetTimestamp: fieldUint64String(response, 3),
+    };
+  }
+
+  async getCardPin(cardId: string) {
+    const response = await this.call('GetCardPin', encodeMessage([protoString(1, cardId)]), true);
+    return { pin: fieldString(response, 1) };
+  }
+
+  async getCardTransactions(input: {
+    network: SolayerNetwork;
+    startTimestamp?: string;
+    endTimestamp?: string;
+    pageSize?: string;
+    page?: string;
+    cardId?: string;
+  }) {
+    const response = await this.call(
+      'GetCardTransactions',
+      encodeMessage([
+        protoVarint(1, input.network),
+        protoVarint(2, input.startTimestamp ? BigInt(input.startTimestamp) : undefined),
+        protoVarint(3, input.endTimestamp ? BigInt(input.endTimestamp) : undefined),
+        protoVarint(4, input.pageSize ? BigInt(input.pageSize) : undefined),
+        protoVarint(5, input.page ? BigInt(input.page) : undefined),
+        protoString(6, input.cardId),
+      ]),
+      true,
+    );
+    return {
+      cardTransactions: fieldMessages(response, 1).map(decodeCardTransaction),
+      rewardPoints: fieldUint64String(response, 2),
+      totalSize: fieldUint64String(response, 3),
+    };
+  }
+}
+
+export function createSolayerClient(options: SolayerClientOptions = {}): SolayerClient {
+  const stored = readStoredSolayerSession();
+  return new SolayerClient({
+    token: options.token ?? stored?.token ?? null,
+    deviceId: options.deviceId ?? stored?.deviceId,
+    baseUrl: options.baseUrl ?? resolveSolayerBaseUrl(),
+    timeoutMs: options.timeoutMs,
+    transport: options.transport,
+  });
+}
+
+export function parseSolayerSignature(value: string): Uint8Array {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error('signature is required');
+  }
+  if (/^(0x)?[0-9a-f]+$/iu.test(normalized) && normalized.replace(/^0x/iu, '').length % 2 === 0) {
+    return Uint8Array.from(Buffer.from(normalized.replace(/^0x/iu, ''), 'hex'));
+  }
+  const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+  let num = 0n;
+  for (const character of normalized) {
+    const index = alphabet.indexOf(character);
+    if (index === -1) {
+      throw new Error('signature must be hex or base58');
+    }
+    num = num * 58n + BigInt(index);
+  }
+  const bytes: number[] = [];
+  while (num > 0n) {
+    bytes.unshift(Number(num & 0xffn));
+    num >>= 8n;
+  }
+  for (const character of normalized) {
+    if (character !== '1') {
+      break;
+    }
+    bytes.unshift(0);
+  }
+  return Uint8Array.from(bytes);
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,8 +1,9 @@
 import type { Command } from 'commander';
 import { bitrefillCliPlugin } from './bitrefill.js';
-import { registerCliPlugins, type CliPluginContext } from './types.js';
+import { solayerCliPlugin } from './solayer.js';
+import { type CliPluginContext, registerCliPlugins } from './types.js';
 
-const BUILTIN_CLI_PLUGINS = [bitrefillCliPlugin];
+const BUILTIN_CLI_PLUGINS = [bitrefillCliPlugin, solayerCliPlugin];
 
 export function registerBuiltinCliPlugins(program: Command, context: CliPluginContext): void {
   registerCliPlugins(program, context, BUILTIN_CLI_PLUGINS);

--- a/src/plugins/solayer.js
+++ b/src/plugins/solayer.js
@@ -1,0 +1,1 @@
+export * from './solayer.ts';

--- a/src/plugins/solayer.ts
+++ b/src/plugins/solayer.ts
@@ -1,0 +1,860 @@
+import type { WlfiConfig } from '../../packages/config/src/index.js';
+import {
+  formatConfiguredAmount,
+  normalizeAgentAmountOutput,
+  parseConfiguredAmount,
+} from '../lib/config-amounts.js';
+import {
+  createSolayerClient,
+  deleteStoredSolayerSession,
+  parseSolayerSignature,
+  readStoredSolayerSession,
+  redactSolayerSensitiveFields,
+  resolveSolayerNetwork,
+  SolayerCardLimitPeriod,
+  SolayerCardType,
+  type SolayerClient,
+  SolayerEmailType,
+  SolayerSignatureMessageType,
+  storeSolayerSession,
+} from '../lib/solayer.js';
+import type { CliPlugin, CliPluginContext } from './types.js';
+
+const SOLAYER_USDC_MAINNET_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+interface JsonOptions {
+  json: boolean;
+}
+
+interface NetworkOptions extends JsonOptions {
+  network?: string;
+}
+
+interface SolayerWalletLoginOptions extends NetworkOptions, Record<string, unknown> {}
+
+interface SolayerExternalPrepareOptions extends NetworkOptions {
+  address: string;
+  transaction: boolean;
+}
+
+interface SolayerExternalVerifyOptions extends NetworkOptions {
+  address: string;
+  messageId: string;
+  signature: string;
+  walletName?: string;
+  txB64?: string;
+}
+
+interface SolayerEmailLoginOptions extends NetworkOptions {
+  email: string;
+}
+
+interface SolayerEmailVerifyOptions extends NetworkOptions {
+  sessionId: string;
+  otp: string;
+  signup: boolean;
+}
+
+interface SolayerSocialLoginOptions extends JsonOptions {
+  provider: 'google' | 'apple';
+  tokenStdin: boolean;
+  signup: boolean;
+}
+
+interface SolayerFundOptions extends NetworkOptions, Record<string, unknown> {
+  amount: string;
+  broadcast: boolean;
+  rpcUrl?: string;
+  feePayer?: string;
+  mint?: string;
+  durableNonceAccount?: string;
+  computeUnitLimit?: string;
+  computeUnitPriceMicroLamports?: string;
+  wait: boolean;
+  revealRawTx: boolean;
+}
+
+interface SolayerCreateCardOptions extends NetworkOptions {
+  name?: string;
+  limitPeriod?: string;
+  limitUsd?: string;
+  revealSensitive: boolean;
+}
+
+interface SolayerCardIdOptions extends NetworkOptions {
+  cardId: string;
+  revealSensitive: boolean;
+  tfaSessionId?: string;
+}
+
+interface SolayerCardTransactionsOptions extends NetworkOptions {
+  cardId?: string;
+  start?: string;
+  end?: string;
+  pageSize?: string;
+  page?: string;
+}
+
+function requireString(value: string | undefined, label: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function parseLimitPeriod(value: string | undefined): SolayerCardLimitPeriod | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  switch (normalized) {
+    case 'day':
+      return SolayerCardLimitPeriod.Day;
+    case 'week':
+      return SolayerCardLimitPeriod.Week;
+    case 'month':
+      return SolayerCardLimitPeriod.Month;
+    case 'year':
+      return SolayerCardLimitPeriod.Year;
+    case 'total':
+      return SolayerCardLimitPeriod.Total;
+    default:
+      throw new Error('--limit-period must be one of day, week, month, year, total');
+  }
+}
+
+function writeSolayerOutput(
+  context: CliPluginContext,
+  value: unknown,
+  options: { json: boolean; revealSensitive?: boolean },
+): void {
+  context.cli.print(redactSolayerSensitiveFields(value, options.revealSensitive), options.json);
+}
+
+function solayerClient(): SolayerClient {
+  return createSolayerClient();
+}
+
+async function readSecretFromStdin(label: string): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error(`${label} must be provided with --token-stdin`);
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const value = Buffer.concat(chunks).toString('utf8').trim();
+  if (!value) {
+    throw new Error(`${label} is required on stdin`);
+  }
+  return value;
+}
+
+async function completeAuthSession(input: {
+  client: SolayerClient;
+  sessionId: string;
+  exists: boolean;
+  signup: boolean;
+}) {
+  if (!input.exists && !input.signup) {
+    throw new Error('Solayer account does not exist; rerun with --signup to create it');
+  }
+  const result = input.exists
+    ? await input.client.signIn(input.sessionId)
+    : await input.client.signUp(input.sessionId);
+  if (!result.token) {
+    throw new Error('Solayer did not return a session token');
+  }
+  return storeSolayerSession({
+    token: result.token,
+    deviceId: input.client.deviceId,
+  });
+}
+
+function resolveSolayerUsdcMint(
+  config: WlfiConfig,
+  network: string | undefined,
+  override?: string,
+): string {
+  const explicit = override?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const networkKey = network?.trim() || 'solana-mainnet';
+  const configured = config.tokens?.usdc?.chains?.[networkKey]?.address?.trim();
+  return configured || SOLAYER_USDC_MAINNET_MINT;
+}
+
+function solayerNetworkSelector(network: string | undefined): string {
+  return network?.trim() || 'solana-mainnet';
+}
+
+function solayerChainId(network: string | undefined): number {
+  return solayerNetworkSelector(network) === 'solana-testnet' ? 900000003 : 900000001;
+}
+
+function humanAmountFromBaseUnits(amountWei: bigint, decimals: number): string {
+  return formatConfiguredAmount(amountWei, decimals);
+}
+
+async function runSolayerWalletLogin(
+  context: CliPluginContext,
+  options: SolayerWalletLoginOptions,
+) {
+  const config = context.config.readConfig();
+  const address = await context.solana.resolveWalletAddress(config);
+  const client = solayerClient();
+  const network = resolveSolayerNetwork(options.network);
+  const prepared = await client.getSignatureMessage({
+    network,
+    address,
+    messageType: SolayerSignatureMessageType.WalletMessage,
+  });
+  if (!prepared.message || !prepared.messageId) {
+    throw new Error('Solayer did not return a wallet login challenge');
+  }
+  const signed = await context.agent.runJson<{
+    command: string;
+    network: string;
+    asset: string;
+    counterparty: string;
+    amount_wei: string;
+    signature_hex: string;
+    signature_base58?: string;
+  }>({
+    commandArgs: [
+      'solana-message-sign',
+      '--network',
+      String(solayerChainId(options.network)),
+      '--address',
+      address,
+      '--domain',
+      'solayer',
+      '--message',
+      prepared.message,
+    ],
+    auth: options,
+    config,
+    asJson: options.json,
+    waitForManualApproval: true,
+  });
+  if (!signed) {
+    return;
+  }
+  const signature = signed.signature_base58 ?? signed.signature_hex;
+  if (!signature) {
+    throw new Error('Rust agent did not return a Solayer wallet signature');
+  }
+  const verified = await client.verifySignature({
+    network,
+    address,
+    signature: parseSolayerSignature(signature),
+    messageId: prepared.messageId,
+    walletName: 'AgentPay',
+  });
+  const stored = storeSolayerSession({
+    token: verified.token,
+    deviceId: client.deviceId,
+  });
+  writeSolayerOutput(
+    context,
+    {
+      authenticated: true,
+      address,
+      updatedAt: stored.updatedAt,
+      deviceId: stored.deviceId,
+    },
+    options,
+  );
+}
+
+async function runSolayerFund(context: CliPluginContext, options: SolayerFundOptions) {
+  const config = context.config.readConfig();
+  const networkSelector = solayerNetworkSelector(options.network);
+  const network = resolveSolayerNetwork(networkSelector);
+  const rpcUrl = context.config.resolveCliRpcUrl(options.rpcUrl, networkSelector, config);
+  const client = solayerClient();
+  const { depositAddress } = await client.getDepositAddress(network);
+  const mint = resolveSolayerUsdcMint(config, networkSelector, options.mint);
+  const feePayer = options.feePayer?.trim() || (await context.solana.resolveWalletAddress(config));
+  const transferContext = await context.solana.resolveSplTransferContext({
+    rpcUrl,
+    feePayer,
+    mint,
+    recipientOwner: depositAddress,
+  });
+  const amountWei = parseConfiguredAmount(options.amount, transferContext.asset.decimals, 'amount');
+  const computeBudget = await context.solana.resolveComputeBudget({
+    rpcUrl,
+    defaultComputeUnitLimit: context.solana.defaults.splTransferComputeUnitLimit,
+    computeUnitLimit: options.computeUnitLimit,
+    computeUnitPriceMicroLamports: options.computeUnitPriceMicroLamports,
+  });
+  const transferFee = await context.solana.resolveTransferFee({
+    rpcUrl,
+    mint: transferContext.mint,
+    tokenProgram: transferContext.tokenProgram,
+    amountWei,
+  });
+  const resolveDurableNonce = () =>
+    options.broadcast || options.durableNonceAccount
+      ? context.solana.resolveDurableNonceForBroadcast({
+          rpcUrl,
+          chainId: solayerChainId(networkSelector),
+          recentBlockhash: transferContext.recentBlockhash,
+          feePayer: transferContext.feePayer,
+          explicitNonceAccount: options.durableNonceAccount,
+          auth: options,
+          config,
+          asJson: options.json,
+        })
+      : Promise.resolve(null);
+
+  const signed = await context.agent.runJson<{
+    command: string;
+    network: string;
+    asset: string;
+    counterparty: string;
+    amount_wei: string;
+    signature_hex: string;
+    signature_base58?: string;
+    raw_tx_base64?: string;
+    tx_id?: string;
+  }>({
+    commandArgs: async () => {
+      const durableNonce = await resolveDurableNonce();
+      return [
+        'solana-spl-transfer',
+        '--network',
+        String(solayerChainId(networkSelector)),
+        '--recent-blockhash',
+        durableNonce?.nonce ?? transferContext.recentBlockhash,
+        ...(durableNonce ? ['--durable-nonce-account', durableNonce.nonceAccount] : []),
+        '--fee-payer',
+        transferContext.feePayer,
+        '--mint',
+        transferContext.mint,
+        '--recipient-owner',
+        transferContext.recipientOwner,
+        '--amount-wei',
+        amountWei.toString(),
+        '--decimals',
+        String(transferContext.asset.decimals),
+        '--token-program',
+        transferContext.tokenProgram,
+        ...(transferFee.transferFeeWei ? ['--transfer-fee-wei', transferFee.transferFeeWei] : []),
+        ...(computeBudget.computeUnitLimit
+          ? ['--compute-unit-limit', computeBudget.computeUnitLimit]
+          : []),
+        ...(computeBudget.computeUnitPriceMicroLamports
+          ? ['--compute-unit-price-micro-lamports', computeBudget.computeUnitPriceMicroLamports]
+          : []),
+      ];
+    },
+    auth: options,
+    config,
+    asJson: options.json,
+    waitForManualApproval: options.broadcast,
+  });
+  if (!signed) {
+    return;
+  }
+
+  const normalized = normalizeAgentAmountOutput(signed, transferContext.asset);
+  if (!options.broadcast) {
+    writeSolayerOutput(
+      context,
+      {
+        mode: 'preview',
+        depositAddress,
+        network: networkSelector,
+        mint,
+        amount: humanAmountFromBaseUnits(amountWei, transferContext.asset.decimals),
+        amountBaseUnits: amountWei.toString(),
+        transfer: normalized,
+      },
+      options,
+    );
+    return;
+  }
+
+  if (!signed.raw_tx_base64) {
+    throw new Error('Rust agent did not return raw_tx_base64 for Solayer funding transfer');
+  }
+  const networkTxId = await context.solana.broadcastSignedTransaction(rpcUrl, signed.raw_tx_base64);
+  writeSolayerOutput(
+    context,
+    {
+      mode: 'broadcast',
+      depositAddress,
+      network: networkSelector,
+      mint,
+      amount: humanAmountFromBaseUnits(amountWei, transferContext.asset.decimals),
+      amountBaseUnits: amountWei.toString(),
+      txId: signed.tx_id ?? null,
+      networkTxId,
+      rawTxBase64: options.revealRawTx ? signed.raw_tx_base64 : undefined,
+      transfer: normalized,
+    },
+    options,
+  );
+  if (options.wait) {
+    await context.solana.reportSignatureStatus({
+      rpcUrl,
+      signature: networkTxId,
+      asJson: options.json,
+    });
+  }
+}
+
+export const solayerCliPlugin: CliPlugin = {
+  name: 'solayer',
+  register(program, context) {
+    const solayer = program
+      .command('solayer')
+      .description('Solayer Pay account, funding, and card operations');
+
+    const session = solayer.command('session').description('Manage Solayer session state');
+    session
+      .command('status')
+      .option('--json', 'Print JSON output', false)
+      .action((options: JsonOptions) => {
+        const stored = readStoredSolayerSession();
+        writeSolayerOutput(
+          context,
+          {
+            authenticated: Boolean(stored),
+            updatedAt: stored?.updatedAt ?? null,
+            deviceId: stored?.deviceId ?? null,
+          },
+          options,
+        );
+      });
+    session
+      .command('logout')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: JsonOptions) => {
+        const client = solayerClient();
+        const hadSession = Boolean(readStoredSolayerSession());
+        if (hadSession) {
+          try {
+            await client.logout();
+          } catch {}
+        }
+        const removed = deleteStoredSolayerSession();
+        writeSolayerOutput(context, { removed }, options);
+      });
+
+    const login = solayer.command('login').description('Authenticate with Solayer');
+    context.cli
+      .addAgentCommandAuthOptions(
+        login
+          .command('wallet')
+          .description('Login with the local AgentPay Solana wallet')
+          .option('--network <name>', 'Solayer network', 'solana-mainnet'),
+      )
+      .action(async (options: SolayerWalletLoginOptions) => {
+        await runSolayerWalletLogin(context, options);
+      });
+
+    const externalWallet = login
+      .command('external-wallet')
+      .description('Login with an externally signed Solayer wallet challenge');
+    externalWallet
+      .command('prepare')
+      .requiredOption('--address <address>', 'Solana wallet address')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option(
+        '--transaction',
+        'Prepare a wallet transaction challenge instead of a message challenge',
+        false,
+      )
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerExternalPrepareOptions) => {
+        const client = solayerClient();
+        const prepared = await client.getSignatureMessage({
+          network: resolveSolayerNetwork(options.network),
+          address: options.address,
+          messageType: options.transaction
+            ? SolayerSignatureMessageType.WalletTransaction
+            : SolayerSignatureMessageType.WalletMessage,
+        });
+        writeSolayerOutput(
+          context,
+          {
+            ...prepared,
+            address: options.address,
+            network: options.network ?? 'solana-mainnet',
+            mode: options.transaction ? 'transaction' : 'message',
+          },
+          options,
+        );
+      });
+    externalWallet
+      .command('verify')
+      .requiredOption('--address <address>', 'Solana wallet address')
+      .requiredOption('--message-id <id>', 'Solayer message id returned by prepare')
+      .requiredOption('--signature <signature>', 'Signature as hex or base58')
+      .option('--wallet-name <name>', 'Wallet name sent to Solayer', 'AgentPay')
+      .option('--tx-b64 <tx>', 'Signed Solana transaction base64 for transaction challenges')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerExternalVerifyOptions) => {
+        const client = solayerClient();
+        const verified = await client.verifySignature({
+          network: resolveSolayerNetwork(options.network),
+          address: options.address,
+          signature: parseSolayerSignature(options.signature),
+          messageId: options.messageId,
+          walletName: options.walletName ?? 'AgentPay',
+          txB64: options.txB64,
+        });
+        const stored = storeSolayerSession({
+          token: verified.token,
+          deviceId: client.deviceId,
+        });
+        writeSolayerOutput(
+          context,
+          {
+            authenticated: true,
+            updatedAt: stored.updatedAt,
+            deviceId: stored.deviceId,
+          },
+          options,
+        );
+      });
+
+    const email = login.command('email').description('Login with Solayer email OTP');
+    email
+      .command('start')
+      .requiredOption('--email <email>', 'Email address')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerEmailLoginOptions) => {
+        const response = await solayerClient().sendEmail({
+          network: resolveSolayerNetwork(options.network),
+          email: options.email,
+          emailType: SolayerEmailType.Login,
+        });
+        writeSolayerOutput(context, response, options);
+      });
+    email
+      .command('verify')
+      .requiredOption('--session-id <id>', 'OTP session id')
+      .requiredOption('--otp <code>', 'Email OTP')
+      .option('--signup', 'Create the Solayer account if it does not exist', false)
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerEmailVerifyOptions) => {
+        const client = solayerClient();
+        const verified = await client.verifyEmailOtp({
+          network: resolveSolayerNetwork(options.network),
+          sessionId: options.sessionId,
+          otp: options.otp,
+          emailType: SolayerEmailType.Login,
+        });
+        const account = await client.checkAccount({ emailToken: verified.sessionId });
+        const stored = await completeAuthSession({
+          client,
+          sessionId: account.sessionId,
+          exists: account.exists,
+          signup: options.signup,
+        });
+        writeSolayerOutput(
+          context,
+          {
+            authenticated: true,
+            created: !account.exists,
+            updatedAt: stored.updatedAt,
+            deviceId: stored.deviceId,
+          },
+          options,
+        );
+      });
+
+    login
+      .command('social')
+      .requiredOption('--provider <provider>', 'google or apple')
+      .requiredOption('--token-stdin', 'Read provider token from stdin')
+      .option('--signup', 'Create the Solayer account if it does not exist', false)
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerSocialLoginOptions) => {
+        const provider = requireString(options.provider, '--provider').toLowerCase();
+        if (provider !== 'google' && provider !== 'apple') {
+          throw new Error('--provider must be google or apple');
+        }
+        const token = await readSecretFromStdin(`${provider} token`);
+        const client = solayerClient();
+        const account = await client.checkAccount(
+          provider === 'google' ? { googleToken: token } : { appleToken: token },
+        );
+        const stored = await completeAuthSession({
+          client,
+          sessionId: account.sessionId,
+          exists: account.exists,
+          signup: options.signup,
+        });
+        writeSolayerOutput(
+          context,
+          {
+            authenticated: true,
+            created: !account.exists,
+            updatedAt: stored.updatedAt,
+            deviceId: stored.deviceId,
+          },
+          options,
+        );
+      });
+
+    solayer
+      .command('account')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: JsonOptions) => {
+        writeSolayerOutput(context, await solayerClient().getAccountInfo(), options);
+      });
+
+    solayer
+      .command('deposit-address')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: NetworkOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getDepositAddress(resolveSolayerNetwork(options.network)),
+          options,
+        );
+      });
+
+    context.cli
+      .addAgentCommandAuthOptions(
+        solayer
+          .command('fund')
+          .requiredOption('--amount <amount>', 'USDC amount to send to the Solayer deposit address')
+          .option('--network <name>', 'Solayer network', 'solana-mainnet')
+          .option('--mint <address>', 'Override Solana USDC mint')
+          .option(
+            '--broadcast',
+            'Broadcast the funding transfer through the AgentPay daemon path',
+            false,
+          )
+          .option('--rpc-url <url>', 'Solana RPC URL override used only for broadcast')
+          .option(
+            '--fee-payer <address>',
+            'Fee payer override; defaults to configured AgentPay Solana wallet',
+          )
+          .option('--durable-nonce-account <address>', 'Internal Solana nonce account override')
+          .option('--compute-unit-limit <units>', 'Optional compute unit limit override')
+          .option(
+            '--compute-unit-price-micro-lamports <price>',
+            'Optional compute unit price override',
+          )
+          .option('--no-wait', 'Do not wait up to 30s for signature confirmation after broadcast')
+          .option(
+            '--reveal-raw-tx',
+            'Include the signed raw transaction bytes in broadcast output',
+            false,
+          ),
+      )
+      .action(async (options: SolayerFundOptions) => {
+        await runSolayerFund(context, options);
+      });
+
+    const kyc = solayer.command('kyc').description('Manage Solayer KYC state');
+    kyc
+      .command('status')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: NetworkOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getKycInfo(resolveSolayerNetwork(options.network)),
+          options,
+        );
+      });
+    kyc
+      .command('link')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: NetworkOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getKycAuth(resolveSolayerNetwork(options.network)),
+          options,
+        );
+      });
+    kyc
+      .command('email')
+      .requiredOption('--email <email>', 'KYC email address')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerEmailLoginOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().sendEmail({
+            network: resolveSolayerNetwork(options.network),
+            email: options.email,
+            emailType: SolayerEmailType.Kyc,
+          }),
+          options,
+        );
+      });
+    kyc
+      .command('email-verify')
+      .requiredOption('--session-id <id>', 'OTP session id')
+      .requiredOption('--otp <code>', 'Email OTP')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerEmailVerifyOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().verifyEmailOtp({
+            network: resolveSolayerNetwork(options.network),
+            sessionId: options.sessionId,
+            otp: options.otp,
+            emailType: SolayerEmailType.Kyc,
+          }),
+          options,
+        );
+      });
+
+    const protocol = solayer.command('protocol').description('Accept Solayer protocols');
+    protocol
+      .command('accept')
+      .option('--kyc', 'Accept KYC protocol', false)
+      .option('--card', 'Accept card protocol', false)
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: JsonOptions & { kyc?: boolean; card?: boolean }) => {
+        if (!options.kyc && !options.card) {
+          throw new Error('choose --kyc or --card');
+        }
+        await solayerClient().acceptProtocol({ kyc: options.kyc, card: options.card });
+        writeSolayerOutput(context, { accepted: options.kyc ? 'kyc' : 'card' }, options);
+      });
+
+    const application = solayer
+      .command('application')
+      .description('Manage Solayer card application');
+    for (const commandName of ['status', 'create', 'update'] as const) {
+      application
+        .command(commandName)
+        .option('--network <name>', 'Solayer network', 'solana-mainnet')
+        .option('--json', 'Print JSON output', false)
+        .action(async (options: NetworkOptions) => {
+          const client = solayerClient();
+          const network = resolveSolayerNetwork(options.network);
+          const response =
+            commandName === 'create'
+              ? await client.createApplication(network)
+              : commandName === 'update'
+                ? await client.updateApplication(network)
+                : await client.getApplication(network);
+          writeSolayerOutput(context, response, options);
+        });
+    }
+
+    const card = solayer.command('card').description('Manage Solayer cards');
+    card
+      .command('list')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: NetworkOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getCards({ network: resolveSolayerNetwork(options.network) }),
+          options,
+        );
+      });
+    card
+      .command('create')
+      .option('--name <name>', 'Card display name')
+      .option('--limit-period <period>', 'day, week, month, year, or total')
+      .option('--limit-usd <amount>', 'Limit amount in USD')
+      .option('--reveal-sensitive', 'Include PAN/CVC returned by Solayer in command output', false)
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerCreateCardOptions) => {
+        const period = parseLimitPeriod(options.limitPeriod);
+        const response = await solayerClient().createCard({
+          network: resolveSolayerNetwork(options.network),
+          name: options.name,
+          type: SolayerCardType.Virtual,
+          limit:
+            period || options.limitUsd
+              ? {
+                  period,
+                  valueInUsd: options.limitUsd,
+                }
+              : undefined,
+        });
+        writeSolayerOutput(context, response, options);
+      });
+    card
+      .command('details')
+      .requiredOption('--card-id <id>', 'Solayer card id')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerCardIdOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getCardDetails({
+            network: resolveSolayerNetwork(options.network),
+            cardId: options.cardId,
+          }),
+          options,
+        );
+      });
+    card
+      .command('reveal')
+      .requiredOption('--card-id <id>', 'Solayer card id')
+      .requiredOption('--reveal-sensitive', 'Required to print PAN/CVC')
+      .option('--tfa-session-id <id>', 'Solayer TFA session id when required')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerCardIdOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getCardEncryptedInfo({
+            network: resolveSolayerNetwork(options.network),
+            cardId: options.cardId,
+            tfaSessionId: options.tfaSessionId,
+          }),
+          { ...options, revealSensitive: true },
+        );
+      });
+    card
+      .command('pin')
+      .requiredOption('--card-id <id>', 'Solayer card id')
+      .requiredOption('--reveal-sensitive', 'Required to print card PIN')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerCardIdOptions) => {
+        writeSolayerOutput(context, await solayerClient().getCardPin(options.cardId), {
+          ...options,
+          revealSensitive: true,
+        });
+      });
+    card
+      .command('transactions')
+      .option('--card-id <id>', 'Filter by card id')
+      .option('--start <unix-ms>', 'Start timestamp in milliseconds')
+      .option('--end <unix-ms>', 'End timestamp in milliseconds')
+      .option('--page-size <n>', 'Page size')
+      .option('--page <n>', 'Page number')
+      .option('--network <name>', 'Solayer network', 'solana-mainnet')
+      .option('--json', 'Print JSON output', false)
+      .action(async (options: SolayerCardTransactionsOptions) => {
+        writeSolayerOutput(
+          context,
+          await solayerClient().getCardTransactions({
+            network: resolveSolayerNetwork(options.network),
+            startTimestamp: options.start,
+            endTimestamp: options.end,
+            pageSize: options.pageSize,
+            page: options.page,
+            cardId: options.cardId,
+          }),
+          options,
+        );
+      });
+  },
+};

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,3 +1,5 @@
+import type { Command } from 'commander';
+import type { Address, Hex } from 'viem';
 import type { WlfiConfig } from '../../packages/config/src/index.js';
 import type {
   AssetBroadcastPlan,
@@ -7,8 +9,11 @@ import type {
   ResolveAssetBroadcastPlanDeps,
 } from '../lib/asset-broadcast.js';
 import type { ResolvedAssetMetadata, RustAmountOutputShape } from '../lib/config-amounts.js';
-import type { Command } from 'commander';
-import type { Address, Hex } from 'viem';
+import type {
+  SolanaComputeBudget,
+  SolanaSolTransferContext,
+  SolanaTransferContext,
+} from '../lib/solana-transfer.js';
 
 export interface CliPluginContext {
   cli: {
@@ -30,7 +35,7 @@ export interface CliPluginContext {
   };
   agent: {
     runJson: <T>(input: {
-      commandArgs: string[];
+      commandArgs: string[] | (() => Promise<string[]> | string[]);
       auth: Record<string, unknown>;
       config: WlfiConfig;
       asJson: boolean;
@@ -66,6 +71,55 @@ export interface CliPluginContext {
       txHash: Hex;
       asJson: boolean;
     }) => Promise<void>;
+  };
+  solana: {
+    resolveWalletAddress: (config: WlfiConfig) => Promise<string> | string;
+    resolveSolTransferContext: (input: {
+      rpcUrl: string;
+      feePayer: string;
+      recipient: string;
+    }) => Promise<SolanaSolTransferContext>;
+    resolveSplTransferContext: (input: {
+      rpcUrl: string;
+      feePayer: string;
+      mint: string;
+      recipientOwner: string;
+    }) => Promise<SolanaTransferContext>;
+    resolveTransferFee: (input: {
+      rpcUrl: string;
+      mint: string;
+      tokenProgram: SolanaTransferContext['tokenProgram'];
+      amountWei: bigint;
+    }) => Promise<{ transferInstruction: string; transferFeeWei: string | null }>;
+    resolveComputeBudget: (input: {
+      rpcUrl: string;
+      defaultComputeUnitLimit: number;
+      computeUnitLimit?: string;
+      computeUnitPriceMicroLamports?: string;
+    }) => Promise<SolanaComputeBudget>;
+    resolveDurableNonceForBroadcast: (input: {
+      rpcUrl: string;
+      chainId: string | number;
+      recentBlockhash: string;
+      feePayer: string;
+      explicitNonceAccount?: string;
+      auth: Record<string, unknown>;
+      config: WlfiConfig;
+      asJson: boolean;
+    }) => Promise<{ nonceAccount: string; nonceAuthority: string; nonce: string }>;
+    broadcastSignedTransaction: (
+      rpcUrl: string,
+      signedTransactionBase64: string,
+    ) => Promise<string>;
+    reportSignatureStatus: (input: {
+      rpcUrl: string;
+      signature: string;
+      asJson: boolean;
+    }) => Promise<void>;
+    defaults: {
+      solTransferComputeUnitLimit: number;
+      splTransferComputeUnitLimit: number;
+    };
   };
   exitCodes: {
     challengeRequired: number;

--- a/test/solayer-cli.test.mjs
+++ b/test/solayer-cli.test.mjs
@@ -1,0 +1,303 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+
+function makeIsolatedHome() {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentpay-solayer-home-'));
+  const agentpayHome = path.join(homeDir, '.agentpay');
+  fs.mkdirSync(agentpayHome, { recursive: true, mode: 0o700 });
+  return { homeDir, agentpayHome };
+}
+
+function runCli(args, { homeDir, input = '', env = {} }) {
+  const agentpayHome = path.join(homeDir, '.agentpay');
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        AGENTPAY_HOME: agentpayHome,
+        ...env,
+      },
+      stdio: 'pipe',
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (status, signal) => {
+      resolve({
+        status:
+          status ??
+          (typeof signal === 'string' && typeof os.constants.signals[signal] === 'number'
+            ? 128 + os.constants.signals[signal]
+            : 1),
+        stdout,
+        stderr,
+      });
+    });
+    if (input) {
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+function combinedOutput(result) {
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+async function closeServer(server) {
+  if (typeof server.closeAllConnections === 'function') {
+    server.closeAllConnections();
+  }
+  await new Promise((resolve) => {
+    server.close(() => resolve(undefined));
+  });
+}
+
+function writeVarint(value) {
+  let remaining = BigInt(value);
+  const bytes = [];
+  while (remaining >= 0x80n) {
+    bytes.push(Number((remaining & 0x7fn) | 0x80n));
+    remaining >>= 7n;
+  }
+  bytes.push(Number(remaining));
+  return Uint8Array.from(bytes);
+}
+
+function concat(chunks) {
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function key(field, wire) {
+  return writeVarint((field << 3) | wire);
+}
+
+function stringField(field, value) {
+  if (!value) {
+    return [];
+  }
+  const bytes = Buffer.from(value, 'utf8');
+  return [key(field, 2), writeVarint(bytes.length), bytes];
+}
+
+function varintField(field, value) {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [key(field, 0), writeVarint(value === true ? 1 : value === false ? 0 : value)];
+}
+
+function encodeMessage(fields) {
+  return concat(fields.flat());
+}
+
+function grpcFrame(message) {
+  const output = new Uint8Array(5 + message.length);
+  output[0] = 0;
+  new DataView(output.buffer).setUint32(1, message.length, false);
+  output.set(message, 5);
+  return Buffer.from(output);
+}
+
+function startSolayerServer() {
+  const calls = [];
+  const server = http.createServer((req, res) => {
+    req.resume();
+    const method = req.url.split('/').pop();
+    calls.push({
+      method,
+      authorization: req.headers.authorization ?? null,
+      browserId: req.headers['browser-id'] ?? null,
+      platform: req.headers.platform ?? null,
+    });
+
+    let body;
+    switch (method) {
+      case 'GetSignatureMessage':
+        body = encodeMessage([
+          stringField(1, 'You are logging into Solayer.\n\n\nYour challenge is: test'),
+          stringField(2, 'message-1'),
+        ]);
+        break;
+      case 'VerifySignature':
+        body = encodeMessage([stringField(1, 'solayer-token-1')]);
+        break;
+      case 'SendEmail':
+        body = encodeMessage([stringField(1, 'email-session-1')]);
+        break;
+      case 'VerifyEmailOTP':
+        body = encodeMessage([stringField(1, 'email-token-1')]);
+        break;
+      case 'CheckAccount':
+        body = encodeMessage([varintField(1, true), stringField(2, 'auth-session-1')]);
+        break;
+      case 'SignIn':
+        body = encodeMessage([stringField(1, 'solayer-email-token-1')]);
+        break;
+      case 'GetDepositAddress':
+        body = encodeMessage([stringField(1, 'EZYC52PvmZrsifqU6Dpt9qZ3onYmBpUR1UmFn47i3KF7')]);
+        break;
+      default:
+        res.statusCode = 404;
+        res.end();
+        return;
+    }
+    res.setHeader('content-type', 'application/grpc-web+proto');
+    res.end(grpcFrame(body));
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        server,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        calls,
+      });
+    });
+  });
+}
+
+test('solayer external wallet prepare and verify stores a redacted session', async () => {
+  const { homeDir } = makeIsolatedHome();
+  const { server, baseUrl, calls } = await startSolayerServer();
+
+  try {
+    const prepare = await runCli(
+      [
+        'solayer',
+        'login',
+        'external-wallet',
+        'prepare',
+        '--address',
+        'So11111111111111111111111111111111111111112',
+        '--json',
+      ],
+      {
+        homeDir,
+        env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+      },
+    );
+    assert.equal(prepare.status, 0, combinedOutput(prepare));
+    const prepared = JSON.parse(prepare.stdout);
+    assert.equal(prepared.messageId, 'message-1');
+    assert.match(prepared.message, /logging into Solayer/u);
+
+    const verify = await runCli(
+      [
+        'solayer',
+        'login',
+        'external-wallet',
+        'verify',
+        '--address',
+        'So11111111111111111111111111111111111111112',
+        '--message-id',
+        'message-1',
+        '--signature',
+        `0x${'11'.repeat(64)}`,
+        '--json',
+      ],
+      {
+        homeDir,
+        env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+      },
+    );
+    assert.equal(verify.status, 0, combinedOutput(verify));
+    assert.doesNotMatch(verify.stdout, /solayer-token-1/u);
+    assert.equal(JSON.parse(verify.stdout).authenticated, true);
+
+    const status = await runCli(['solayer', 'session', 'status', '--json'], {
+      homeDir,
+      env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+    });
+    assert.equal(status.status, 0, combinedOutput(status));
+    assert.equal(JSON.parse(status.stdout).authenticated, true);
+    assert.doesNotMatch(status.stdout, /solayer-token-1/u);
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      ['GetSignatureMessage', 'VerifySignature'],
+    );
+  } finally {
+    await closeServer(server);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test('solayer email login stores session and authenticated calls send token metadata', async () => {
+  const { homeDir } = makeIsolatedHome();
+  const { server, baseUrl, calls } = await startSolayerServer();
+
+  try {
+    const start = await runCli(
+      ['solayer', 'login', 'email', 'start', '--email', 'user@example.com', '--json'],
+      {
+        homeDir,
+        env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+      },
+    );
+    assert.equal(start.status, 0, combinedOutput(start));
+    assert.equal(JSON.parse(start.stdout).sessionId, 'email-session-1');
+
+    const verify = await runCli(
+      [
+        'solayer',
+        'login',
+        'email',
+        'verify',
+        '--session-id',
+        'email-session-1',
+        '--otp',
+        '123456',
+        '--json',
+      ],
+      {
+        homeDir,
+        env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+      },
+    );
+    assert.equal(verify.status, 0, combinedOutput(verify));
+    assert.doesNotMatch(verify.stdout, /solayer-email-token-1/u);
+
+    const deposit = await runCli(['solayer', 'deposit-address', '--json'], {
+      homeDir,
+      env: { AGENTPAY_SOLAYER_BASE_URL: baseUrl },
+    });
+    assert.equal(deposit.status, 0, combinedOutput(deposit));
+    assert.equal(
+      JSON.parse(deposit.stdout).depositAddress,
+      'EZYC52PvmZrsifqU6Dpt9qZ3onYmBpUR1UmFn47i3KF7',
+    );
+
+    const depositCall = calls.find((call) => call.method === 'GetDepositAddress');
+    assert.equal(depositCall.authorization, 'solayer-email-token-1');
+    assert.equal(depositCall.platform, 'WEB');
+    assert.ok(depositCall.browserId);
+  } finally {
+    await closeServer(server);
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a Solayer gRPC-web client and `agentpay solayer` plugin for login, session/account, funding, KYC/application/protocol, and card workflows
- wire Solayer funding through AgentPay Solana SPL transfer helpers with policy/manual-approval guardrails
- add a scoped daemon-backed `solana-message-sign` action so `agentpay solayer login wallet` can authenticate with the local AgentPay Solana wallet
- add Solayer CLI integration tests with a local gRPC-web mock server

## Validation
- `git diff --check --cached`
- `pnpm exec biome check src/lib/solayer.ts src/plugins/solayer.ts src/plugins/types.ts src/plugins/index.ts src/cli.ts test/solayer-cli.test.mjs`
- `pnpm exec tsc --noEmit --pretty false`
- `node --experimental-strip-types --test test/solayer-cli.test.mjs`
- `cargo check -p vault-domain -p vault-sdk-agent -p vault-daemon -p agentpay-agent -p agentpay-daemon`

## Notes
- Cargo check passes with existing warnings about the repo's `coverage` cfg/deprecation warnings in signer/daemon code.
- Local `.omx/` tooling state is intentionally not included.