### PR TITLE
Validate cache port configuration

### DIFF
--- a/packages/cache/src/client/index.test.ts
+++ b/packages/cache/src/client/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseCachePort } from './index.js';
+
+describe('parseCachePort', () => {
+  it('uses the default Redis port when unset or blank', () => {
+    expect(parseCachePort(undefined)).toBe(6379);
+    expect(parseCachePort('  ')).toBe(6379);
+  });
+
+  it('accepts explicit valid ports', () => {
+    expect(parseCachePort('6380')).toBe(6380);
+    expect(parseCachePort(' 65535 ')).toBe(65535);
+  });
+
+  it('rejects malformed and out of range ports', () => {
+    for (const value of ['0', '65536', '-1', '12.5', '6379abc', 'Infinity']) {
+      expect(() => parseCachePort(value)).toThrow(
+        /CACHE_PORT must be an integer between 1 and 65535/,
+      );
+    }
+  });
+});

--- a/packages/cache/src/client/index.ts
+++ b/packages/cache/src/client/index.ts
@@ -12,6 +12,20 @@ export interface CacheClientOptions {
 
 let singletonClient: Redis | null = null;
 
+export const parseCachePort = (value: string | undefined): number => {
+  const normalized = value?.trim() || '6379';
+  if (!/^(0|[1-9][0-9]*)$/u.test(normalized)) {
+    throw new Error('CACHE_PORT must be an integer between 1 and 65535');
+  }
+
+  const port = Number(normalized);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+    throw new Error('CACHE_PORT must be an integer between 1 and 65535');
+  }
+
+  return port;
+};
+
 const getDefaultCacheUrl = (): string => {
   const explicitUrl = process.env.CACHE_URL?.trim();
   if (explicitUrl) {
@@ -19,7 +33,7 @@ const getDefaultCacheUrl = (): string => {
   }
 
   const host = process.env.CACHE_HOST?.trim() || '127.0.0.1';
-  const port = Number(process.env.CACHE_PORT?.trim() || '6379');
+  const port = parseCachePort(process.env.CACHE_PORT);
 
   return `redis://${host}:${port}`;
 };


### PR DESCRIPTION
CACHE_PORT was converted with Number, so malformed values like `6379abc` or out of range values could still be passed into the Redis URL.

This adds strict integer range validation before constructing the default cache URL.